### PR TITLE
fix: Fix publish import for CLI

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -9,7 +9,7 @@ import interpret from 'interpret'
 const argv = minimist(args)
 import { pathToFileURL } from 'node:url'
 import { createRequire } from 'node:module'
-import { publish } from '../src/publish.js'
+import { publish } from '../src/publish/index.js'
 import { Command, Option } from 'commander'
 import fs from 'node:fs'
 import { dirname, join } from 'node:path'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "baseUrl": ".",
     "allowUnreachableCode": true
   },
-  "include": ["prettier.config.js", "src"]
+  "include": ["bin", "prettier.config.js", "src"]
 }


### PR DESCRIPTION
Type checking isn't enabled yet (will do now), and it wasn't getting IDE hints since tsconfig didn't include the bin directory.