### PR TITLE
fix: Run ESLint on JS files, sort imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,18 +42,41 @@ const config = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-inferrable-types': [
       'error',
       {
         ignoreParameters: true,
       },
     ],
-    'no-shadow': 'error',
+    'import/default': 'off',
+    'import/export': 'off',
+    'import/namespace': 'off',
+    'import/newline-after-import': 'error',
     'import/no-cycle': 'error',
+    'import/no-duplicates': 'off',
+    'import/no-named-as-default-member': 'off',
     'import/no-unresolved': ['error', { ignore: ['^@tanstack/'] }],
     'import/no-unused-modules': ['off', { unusedExports: true }],
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'type',
+        ],
+      },
+    ],
+
     'no-redeclare': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
+    'no-shadow': 'error',
+    'sort-imports': ['error', { ignoreDeclarationSort: true }],
   },
   overrides: [
     {

--- a/bin/config.js
+++ b/bin/config.js
@@ -30,7 +30,7 @@ async function requireOrImport(path) {
     return require(path)
   } catch (e) {
     // @ts-expect-error
-    if (pathToFileURL && e.code === 'ERR_REQUIRE_ESM') {
+    if (e.code === 'ERR_REQUIRE_ESM') {
       // This is needed on Windows, because import() fails if providing a Windows file path.
       const url = pathToFileURL(path)
       // @ts-expect-error

--- a/bin/config.js
+++ b/bin/config.js
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
-import chalk from 'chalk'
 
-const args = process.argv.slice(2)
+import { pathToFileURL } from 'node:url'
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import chalk from 'chalk'
 import Liftoff from 'liftoff'
 import minimist from 'minimist'
 import v8flags from 'v8flags'
 import interpret from 'interpret'
-const argv = minimist(args)
-import { pathToFileURL } from 'node:url'
-import { createRequire } from 'node:module'
-import { publish } from '../src/publish/index.js'
 import { Command } from 'commander'
-import fs from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { publish } from '../src/publish/index.js'
+
+const args = process.argv.slice(2)
+const argv = minimist(args)
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const pkg = JSON.parse(
-  fs.readFileSync(join(__dirname, '../package.json'), 'utf8'),
-)
+const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
 
 const require = createRequire(import.meta.url)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier:write": "pnpm run prettier --write",
     "test:build": "publint --strict",
     "test:types": "tsc",
-    "test:eslint": "eslint --ext .ts,.tsx src",
+    "test:eslint": "eslint --ext .js,.ts,.tsx ./bin ./src",
     "test:format": "pnpm run prettier --check",
     "test:pr": "nx run-many --targets=test:format,test:eslint,test:types,test:build",
     "test:ci": "nx run-many --targets=test:format,test:eslint,test:types,test:build"

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -89,13 +89,13 @@ export async function publish(options) {
 
   // Filter tags to our branch/pre-release combo
   tags = tags
-    .filter((tag) => semver.valid(tag))
-    .filter((tag) => {
+    .filter((t) => semver.valid(t))
+    .filter((t) => {
       // If this is an older release, filter to only include that version
       if (isPreviousRelease) {
-        return tag.startsWith(branchName)
+        return t.startsWith(branchName)
       }
-      if (semver.prerelease(tag) === null) {
+      if (semver.prerelease(t) === null) {
         return isMainBranch
       } else {
         return !isMainBranch


### PR DESCRIPTION
When I added more ESLint rules, nothing happened. Seems like we forgot to tell eslint to include `.js` files! This PR corrects ESLint to ensure it runs on all the source files, and adds some new rules from `eslint-plugin-import` to keep imports sorted nicely (config from the query repo). I've also fixed a `no-shadow` rule in the publish function.