### PR TITLE
feat: Add rollup-plugin-preserve-directives

### DIFF
--- a/integrations/react/snap/cjs/use-client.cjs
+++ b/integrations/react/snap/cjs/use-client.cjs
@@ -1,3 +1,4 @@
+'use client';
 "use strict";
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const jsxRuntime = require("react/jsx-runtime");

--- a/integrations/react/snap/cjs/use-client.cjs
+++ b/integrations/react/snap/cjs/use-client.cjs
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 "use strict";
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const jsxRuntime = require("react/jsx-runtime");

--- a/integrations/react/snap/cjs/use-client.cjs.map
+++ b/integrations/react/snap/cjs/use-client.cjs.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"use-client.cjs","sources":["../../src/use-client.tsx"],"sourcesContent":["'use client'\n\nexport const Component = () => {\n  return <div>Hello world!</div>\n}\n"],"names":["jsx"],"mappings":";;;AAEO,MAAM,YAAY,MAAM;AACtB,SAAAA,2BAAA,IAAC,SAAI,UAAY,eAAA,CAAA;AAC1B;;"}
+{"version":3,"file":"use-client.cjs","sources":["../../src/use-client.tsx"],"sourcesContent":["'use client'\n\nexport const Component = () => {\n  return <div>Hello world!</div>\n}\n"],"names":[],"mappings":";;;;AAEO;AACE;AACT;;"}

--- a/integrations/react/snap/esm/use-client.js
+++ b/integrations/react/snap/esm/use-client.js
@@ -1,3 +1,4 @@
+'use client';
 import { jsx } from "react/jsx-runtime";
 const Component = () => {
   return /* @__PURE__ */ jsx("div", { children: "Hello world!" });

--- a/integrations/react/snap/esm/use-client.js
+++ b/integrations/react/snap/esm/use-client.js
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 import { jsx } from "react/jsx-runtime";
 const Component = () => {
   return /* @__PURE__ */ jsx("div", { children: "Hello world!" });

--- a/integrations/react/snap/esm/use-client.js.map
+++ b/integrations/react/snap/esm/use-client.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"use-client.js","sources":["../../src/use-client.tsx"],"sourcesContent":["'use client'\n\nexport const Component = () => {\n  return <div>Hello world!</div>\n}\n"],"names":[],"mappings":";AAEO,MAAM,YAAY,MAAM;AACtB,SAAA,oBAAC,SAAI,UAAY,eAAA,CAAA;AAC1B;"}
+{"version":3,"file":"use-client.js","sources":["../../src/use-client.tsx"],"sourcesContent":["'use client'\n\nexport const Component = () => {\n  return <div>Hello world!</div>\n}\n"],"names":[],"mappings":";;AAEO;AACE;AACT;;;;"}

--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,7 @@
     "defaultBase": "main"
   },
   "defaultBase": "main",
+  "parallel": 5,
   "targetDefaults": {
     "test:build": {
       "cache": true

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "liftoff": "^4.0.0",
     "luxon": "^3.4.4",
     "minimist": "^1.2.8",
+    "rollup-plugin-preserve-directives": "^0.2.0",
     "semver": "^7.5.4",
     "stream-to-array": "^2.3.0",
     "v8flags": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "liftoff": "^4.0.0",
     "luxon": "^3.4.4",
     "minimist": "^1.2.8",
-    "rollup-plugin-preserve-directives": "^0.2.0",
+    "rollup-plugin-preserve-directives": "^0.3.0",
     "semver": "^7.5.4",
     "stream-to-array": "^2.3.0",
     "v8flags": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "liftoff": "^4.0.0",
     "luxon": "^3.4.4",
     "minimist": "^1.2.8",
-    "rollup-plugin-preserve-directives": "^0.3.0",
+    "rollup-plugin-preserve-directives": "^0.3.1",
     "semver": "^7.5.4",
     "stream-to-array": "^2.3.0",
     "v8flags": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      rollup-plugin-preserve-directives:
+        specifier: ^0.2.0
+        version: 0.2.0(rollup@3.29.4)
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -52,7 +55,7 @@ importers:
         version: 4.0.1
       vite-plugin-dts:
         specifier: ^3.7.0
-        version: 3.7.0(@types/node@18.19.4)(typescript@5.3.3)(vite@5.0.10)
+        version: 3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
       vite-plugin-externalize-deps:
         specifier: ^0.8.0
         version: 0.8.0(vite@5.0.10)
@@ -1025,7 +1028,7 @@ packages:
       zeptomatch: 1.2.2
     dev: true
 
-  /@rollup/pluginutils@5.1.0:
+  /@rollup/pluginutils@5.1.0(rollup@3.29.4):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1037,6 +1040,7 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.29.4
     dev: false
 
   /@rollup/rollup-android-arm-eabi@4.9.2:
@@ -4359,6 +4363,23 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rollup-plugin-preserve-directives@0.2.0(rollup@3.29.4):
+    resolution: {integrity: sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==}
+    peerDependencies:
+      rollup: 2.x || 3.x
+    dependencies:
+      magic-string: 0.30.5
+      rollup: 3.29.4
+    dev: false
+
+  /rollup@3.29.4:
+    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
+
   /rollup@4.9.2:
     resolution: {integrity: sha512-66RB8OtFKUTozmVEh3qyNfH+b+z2RXBVloqO2KCC/pjFaGaHtxP9fVfOQKPSGXg2mElmjmxjW/fZ7iKrEpMH5Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5083,7 +5104,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(typescript@5.3.3)(vite@5.0.10):
+  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10):
     resolution: {integrity: sha512-np1uPaYzu98AtPReB8zkMnbjwcNHOABsLhqVOf81b3ol9b5M2wPcAVs8oqPnOpr6Us+7yDXVauwkxsk5+ldmRA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5094,7 +5115,7 @@ packages:
         optional: true
     dependencies:
       '@microsoft/api-extractor': 7.39.0(@types/node@18.19.4)
-      '@rollup/pluginutils': 5.1.0
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       debug: 4.3.4
       kolorist: 1.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       rollup-plugin-preserve-directives:
-        specifier: ^0.3.0
-        version: 0.3.0(rollup@4.9.2)
+        specifier: ^0.3.1
+        version: 0.3.1(rollup@4.9.2)
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -4369,8 +4369,8 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-preserve-directives@0.3.0(rollup@4.9.2):
-    resolution: {integrity: sha512-Q6ZhU0nIlD8+R0NNvdJnfeePDWq4D7isP0pEmcGQ6ixSigPOIia4t7EukorikNe+VpZS8FFTm6zFk7o/3eUEBQ==}
+  /rollup-plugin-preserve-directives@0.3.1(rollup@4.9.2):
+    resolution: {integrity: sha512-Jn1gWU7G55A1sU6eFpXmwknfBasF0XbBzRqsE6nqrb/gun+mGV7nx++CwOSGPJQpFzFqvKm5U4XNKo3LTLi4Hg==}
     peerDependencies:
       rollup: 2.x || 3.x || 4.x
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       rollup-plugin-preserve-directives:
-        specifier: ^0.2.0
-        version: 0.2.0(rollup@3.29.4)
+        specifier: ^0.3.0
+        version: 0.3.0(rollup@4.9.2)
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -55,7 +55,7 @@ importers:
         version: 4.0.1
       vite-plugin-dts:
         specifier: ^3.7.0
-        version: 3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
+        version: 3.7.0(@types/node@18.19.4)(rollup@4.9.2)(typescript@5.3.3)(vite@5.0.10)
       vite-plugin-externalize-deps:
         specifier: ^0.8.0
         version: 0.8.0(vite@5.0.10)
@@ -1028,7 +1028,7 @@ packages:
       zeptomatch: 1.2.2
     dev: true
 
-  /@rollup/pluginutils@5.1.0(rollup@3.29.4):
+  /@rollup/pluginutils@5.1.0(rollup@4.9.2):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1040,7 +1040,7 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.4
+      rollup: 4.9.2
     dev: false
 
   /@rollup/rollup-android-arm-eabi@4.9.2:
@@ -4363,21 +4363,13 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-preserve-directives@0.2.0(rollup@3.29.4):
-    resolution: {integrity: sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==}
+  /rollup-plugin-preserve-directives@0.3.0(rollup@4.9.2):
+    resolution: {integrity: sha512-Q6ZhU0nIlD8+R0NNvdJnfeePDWq4D7isP0pEmcGQ6ixSigPOIia4t7EukorikNe+VpZS8FFTm6zFk7o/3eUEBQ==}
     peerDependencies:
-      rollup: 2.x || 3.x
+      rollup: 2.x || 3.x || 4.x
     dependencies:
       magic-string: 0.30.5
-      rollup: 3.29.4
-    dev: false
-
-  /rollup@3.29.4:
-    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.3
+      rollup: 4.9.2
     dev: false
 
   /rollup@4.9.2:
@@ -5104,7 +5096,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10):
+  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(rollup@4.9.2)(typescript@5.3.3)(vite@5.0.10):
     resolution: {integrity: sha512-np1uPaYzu98AtPReB8zkMnbjwcNHOABsLhqVOf81b3ol9b5M2wPcAVs8oqPnOpr6Us+7yDXVauwkxsk5+ldmRA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5115,7 +5107,7 @@ packages:
         optional: true
     dependencies:
       '@microsoft/api-extractor': 7.39.0(@types/node@18.19.4)
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.2)
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       debug: 4.3.4
       kolorist: 1.8.0

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -1,9 +1,10 @@
 // @ts-check
 
 import { readdirSync, renameSync } from 'node:fs'
+import { defineConfig } from 'vite'
+import preserveDirectives from 'rollup-plugin-preserve-directives'
 import { externalizeDeps } from 'vite-plugin-externalize-deps'
 import dts from 'vite-plugin-dts'
-import { defineConfig } from 'vite'
 
 /**
  * @param {import('./index.js').Options} options
@@ -13,6 +14,7 @@ export const tanstackBuildConfig = (options) => {
   return defineConfig({
     plugins: [
       externalizeDeps(),
+      preserveDirectives(),
       dts({
         outDir: 'dist/esm',
         entryRoot: options.srcDir,

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -2,7 +2,7 @@
 
 import { readdirSync, renameSync } from 'node:fs'
 import { defineConfig } from 'vite'
-import preserveDirectives from 'rollup-plugin-preserve-directives'
+import { preserveDirectives } from 'rollup-plugin-preserve-directives'
 import { externalizeDeps } from 'vite-plugin-externalize-deps'
 import dts from 'vite-plugin-dts'
 


### PR DESCRIPTION
Keeps directives like `"use client"`.

TODO:

- [x] Fix vue-integration (something to do with CSS)
- [x] Wait for 0.3.1 release
