### PR TITLE
feat: Update example dependencies when publishing

### DIFF
--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -367,7 +367,7 @@ export const publish = async (options) => {
   }
 
   if (existsSync(path.resolve(rootDir, 'examples'))) {
-    console.info('Updating examples to use new package versions')
+    console.info('Updating examples to use new package versions...')
     const examplePkgJsonArray = /** @type {string[]} */ (
       readdirSync(path.resolve(rootDir, 'examples'), {
         recursive: true,
@@ -395,6 +395,7 @@ export const publish = async (options) => {
         )
       }
       if (existsSync(path.resolve(rootDir, 'pnpm-lock.yaml'))) {
+        console.info('Updating examples to use new package versions...')
         execSync('pnpm install')
       }
     }

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -3,6 +3,7 @@
 
 import path from 'node:path'
 import { execSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
 import chalk from 'chalk'
 import * as semver from 'semver'
 import currentGitBranch from 'current-git-branch'
@@ -363,6 +364,40 @@ export const publish = async (options) => {
         config.version = version
       },
     )
+  }
+
+  if (existsSync(path.resolve(rootDir, 'examples'))) {
+    console.info('Updating examples to use new package versions')
+    const examplePkgJsonArray = /** @type {string[]} */ (
+      readdirSync(path.resolve(rootDir, 'examples'), {
+        recursive: true,
+      }).filter(
+        (file) =>
+          typeof file === 'string' &&
+          file.includes('package.json') &&
+          !file.includes('node_modules'),
+      )
+    )
+    if (examplePkgJsonArray.length !== 0) {
+      for (const examplePkgJson of examplePkgJsonArray) {
+        await updatePackageJson(
+          path.resolve(rootDir, 'examples', examplePkgJson),
+          (config) => {
+            for (const pkg of changedPackages) {
+              if (config.dependencies?.[pkg.name]) {
+                config.dependencies[pkg.name] = `^${version}`
+              }
+              if (config.devDependencies?.[pkg.name]) {
+                config.devDependencies[pkg.name] = `^${version}`
+              }
+            }
+          },
+        )
+      }
+      if (existsSync(path.resolve(rootDir, 'pnpm-lock.yaml'))) {
+        execSync('pnpm install')
+      }
+    }
   }
 
   if (!process.env.CI) {


### PR DESCRIPTION
PR #18 was reverted because it did not update the lockfile, which was very annoying for anyone submitting new PRs. This changes the logic to run `pnpm install` after modifying example versions, and pushing the new lockfile with the release commit.