### PR TITLE
docs: Relative entry paths

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -57,8 +57,8 @@ const config = defineConfig({
 export default mergeConfig(
   config,
   tanstackBuildConfig({
-    entry: 'src/index.ts',
-    srcDir: 'src',
+    entry: './src/index.ts',
+    srcDir: './src',
   }),
 )
 ```

--- a/integrations/react/vite.config.ts
+++ b/integrations/react/vite.config.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { tanstackBuildConfig } from '@tanstack/config/build'
 
@@ -13,7 +13,7 @@ const config = defineConfig({
 export default mergeConfig(
   config,
   tanstackBuildConfig({
-    entry: 'src/index.ts',
-    srcDir: 'src',
+    entry: './src/index.ts',
+    srcDir: './src',
   }),
 )

--- a/integrations/solid/vite.config.ts
+++ b/integrations/solid/vite.config.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import solid from 'vite-plugin-solid'
 import { tanstackBuildConfig } from '@tanstack/config/build'
 
@@ -13,7 +13,7 @@ const config = defineConfig({
 export default mergeConfig(
   config,
   tanstackBuildConfig({
-    entry: 'src/index.ts',
-    srcDir: 'src',
+    entry: './src/index.ts',
+    srcDir: './src',
   }),
 )

--- a/integrations/vanilla/vite.config.ts
+++ b/integrations/vanilla/vite.config.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackBuildConfig } from '@tanstack/config/build'
 
 const config = defineConfig({
@@ -11,7 +11,7 @@ const config = defineConfig({
 export default mergeConfig(
   config,
   tanstackBuildConfig({
-    entry: 'src/index.ts',
-    srcDir: 'src',
+    entry: './src/index.ts',
+    srcDir: './src',
   }),
 )

--- a/integrations/vue/vite.config.ts
+++ b/integrations/vue/vite.config.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { tanstackBuildConfig } from '@tanstack/config/build'
 
@@ -13,7 +13,7 @@ const config = defineConfig({
 export default mergeConfig(
   config,
   tanstackBuildConfig({
-    entry: 'src/index.ts',
-    srcDir: 'src',
+    entry: './src/index.ts',
+    srcDir: './src',
   }),
 )


### PR DESCRIPTION
Recommend to use `./src/index.ts` instead of `src/index.ts`.