### PR TITLE
feat: Add option to specify build output directory

### DIFF
--- a/src/build/index.d.ts
+++ b/src/build/index.d.ts
@@ -7,6 +7,8 @@ export type Options = {
   srcDir: string
   /** Excluded from type generation, e.g. `[./src/tests]` */
   exclude?: string[]
+  /** Directory where build output will be placed, e.g. `./dist` */
+  outDir?: string
 }
 
 export function tanstackBuildConfig(config: Options): UserConfig

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -10,12 +10,14 @@ import dts from 'vite-plugin-dts'
  * @returns {import('vite').UserConfig}
  */
 export const tanstackBuildConfig = (options) => {
+  const outDir = options.outDir ?? 'dist'
+
   return defineConfig({
     plugins: [
       externalizeDeps(),
       preserveDirectives(),
       dts({
-        outDir: 'dist/esm',
+        outDir: `${outDir}/esm`,
         entryRoot: options.srcDir,
         include: options.srcDir,
         exclude: options.exclude,
@@ -34,7 +36,7 @@ export const tanstackBuildConfig = (options) => {
         },
       }),
       dts({
-        outDir: 'dist/cjs',
+        outDir: `${outDir}/cjs`,
         entryRoot: options.srcDir,
         include: options.srcDir,
         exclude: options.exclude,
@@ -56,7 +58,7 @@ export const tanstackBuildConfig = (options) => {
       }),
     ],
     build: {
-      outDir: 'dist',
+      outDir,
       minify: false,
       sourcemap: true,
       lib: {


### PR DESCRIPTION
Still defaults to `dist`, but can be customised if necessary