### PR TITLE
chore: Fix `vite-plugin-externalize-deps` `except` field

### DIFF
--- a/src/build/index.d.ts
+++ b/src/build/index.d.ts
@@ -10,7 +10,7 @@ export type Options = {
   /** Directory where build output will be placed, e.g. `./dist` */
   outDir?: string
   /** Additional externals to include` */
-  externalInclude?: string[]
+  bundledDeps?: string[]
 }
 
 export function tanstackBuildConfig(config: Options): UserConfig

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -14,7 +14,7 @@ export const tanstackBuildConfig = (options) => {
 
   return defineConfig({
     plugins: [
-      externalizeDeps({ include: options.externalInclude || [] }),
+      externalizeDeps({ except: options.bundledDeps || [] }),
       preserveDirectives(),
       dts({
         outDir: `${outDir}/esm`,


### PR DESCRIPTION
- `include` marks something as excluded
- `except` marks something as to be bundled (confusing I know)
- Renamed `externalInclude` to `bundledDeps` which is clearer IMO