### PR TITLE
fix: replace `bundledDeps` with `externalDeps`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,16 +48,16 @@ const config = {
       { prefer: 'type-imports' },
     ],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/method-signature-style': ['error', 'property'],
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-inferrable-types': [
       'error',
-      {
-        ignoreParameters: true,
-      },
+      { ignoreParameters: true },
     ],
     'import/default': 'off',
     'import/export': 'off',
@@ -83,7 +83,6 @@ const config = {
         ],
       },
     ],
-
     'no-redeclare': 'off',
     'no-shadow': 'error',
     'no-undef': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,7 +36,10 @@ const config = {
     },
   },
   rules: {
-    '@typescript-eslint/array-type': 'off',
+    '@typescript-eslint/array-type': [
+      'error',
+      { default: 'generic', readonly: 'generic' },
+    ],
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',

--- a/src/build/index.d.ts
+++ b/src/build/index.d.ts
@@ -2,15 +2,15 @@ import type { UserConfig } from 'vite'
 
 export type Options = {
   /** Entry file, e.g. `./src/index.ts` */
-  entry: string | string[]
+  entry: string | Array<string>
   /** Source directory used for type generation, e.g. `./src` */
   srcDir: string
   /** Excluded from type generation, e.g. `[./src/tests]` */
-  exclude?: string[]
+  exclude?: Array<string>
   /** Directory where build output will be placed, e.g. `./dist` */
   outDir?: string
-  /** Additional externals to include` */
-  bundledDeps?: string[]
+  /** Additional dependencies to externalize if not detected by `vite-plugin-externalize-deps` */
+  externalDeps?: Array<string | RegExp>
 }
 
 export function tanstackBuildConfig(config: Options): UserConfig

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -14,7 +14,7 @@ export const tanstackBuildConfig = (options) => {
 
   return defineConfig({
     plugins: [
-      externalizeDeps({ except: options.bundledDeps || [] }),
+      externalizeDeps({ include: options.externalDeps ?? [] }),
       preserveDirectives(),
       dts({
         outDir: `${outDir}/esm`,

--- a/src/publish/types.d.ts
+++ b/src/publish/types.d.ts
@@ -48,7 +48,7 @@ export type RunOptions = {
   // Contains config for publishable branches.
   branchConfigs: Record<string, BranchConfig>
   // List your npm packages here. The first package will be used as the versioner.
-  packages: Package[]
+  packages: Array<Package>
   rootDir: string
   // The branch to publish. Defaults to the current branch if none supplied.
   branch?: string


### PR DESCRIPTION
Re-fixes #42 after my confusion around option naming 🤦 

New description:
```
/** Additional dependencies to externalize if not detected by `vite-plugin-externalize-deps` */
externalDeps?: Array<string | RegExp>
```

Note `bundledDeps` did not work (included `node_modules` in output), so it has been removed