### PR TITLE
feat: Add `vite-tsconfig-paths` plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "stream-to-array": "^2.3.0",
     "v8flags": "^4.0.1",
     "vite-plugin-dts": "^3.7.2",
-    "vite-plugin-externalize-deps": "^0.8.0"
+    "vite-plugin-externalize-deps": "^0.8.0",
+    "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.13.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       vite-plugin-externalize-deps:
         specifier: ^0.8.0
         version: 0.8.0(vite@5.1.3)
+      vite-tsconfig-paths:
+        specifier: ^4.3.1
+        version: 4.3.1(typescript@5.3.3)(vite@5.1.3)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.13.10
@@ -3032,6 +3035,10 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
+
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -5022,6 +5029,19 @@ packages:
     resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
     dev: true
 
+  /tsconfck@3.0.2(typescript@5.3.3):
+    resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.3.3
+    dev: false
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -5275,6 +5295,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /vite-tsconfig-paths@4.3.1(typescript@5.3.3)(vite@5.1.3):
+    resolution: {integrity: sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.2(typescript@5.3.3)
+      vite: 5.1.3(@types/node@18.19.8)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
 
   /vite@5.1.3(@types/node@18.19.8):
     resolution: {integrity: sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==}

--- a/src/build/index.d.ts
+++ b/src/build/index.d.ts
@@ -13,4 +13,5 @@ export type Options = {
   externalDeps?: Array<string | RegExp>
 }
 
+/** https://tanstack.com/config/latest/docs/build */
 export function tanstackBuildConfig(config: Options): UserConfig

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -3,6 +3,7 @@
 import { defineConfig } from 'vite'
 import { preserveDirectives } from 'rollup-plugin-preserve-directives'
 import { externalizeDeps } from 'vite-plugin-externalize-deps'
+import tsconfigPaths from 'vite-tsconfig-paths'
 import dts from 'vite-plugin-dts'
 
 /**
@@ -16,6 +17,7 @@ export const tanstackBuildConfig = (options) => {
     plugins: [
       externalizeDeps({ include: options.externalDeps ?? [] }),
       preserveDirectives(),
+      tsconfigPaths(),
       dts({
         outDir: `${outDir}/esm`,
         entryRoot: options.srcDir,

--- a/src/publish/index.d.ts
+++ b/src/publish/index.d.ts
@@ -1,3 +1,4 @@
 import type { RunOptions } from './types'
 
+/** https://tanstack.com/config/latest/docs/publish */
 export function publish(options: RunOptions): Promise<void>


### PR DESCRIPTION
Allows Vite to automatically alias paths in tsconfig, meaning you don't need to double-up on the same config.