### PR TITLE
fix(publish): Remove scripts section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
           fetch-depth: '0'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
       - name: Setup Node

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,8 +25,6 @@ jobs:
           fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
       - name: Setup Node

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -405,6 +405,16 @@ export const publish = async (options) => {
     }
   }
 
+  // Remove scripts section from changed packages
+  changedPackages.forEach(async (pkg) => {
+    await updatePackageJson(
+      path.resolve(rootDir, pkg.packageDir, 'package.json'),
+      (config) => {
+        config.scripts = {}
+      },
+    )
+  })
+
   if (!process.env.CI) {
     console.warn(
       `This is a dry run for version ${version}. Push to CI to publish for real or set CI=true to override!`,

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -405,16 +405,6 @@ export const publish = async (options) => {
     }
   }
 
-  // Remove scripts section from changed packages
-  changedPackages.forEach(async (pkg) => {
-    await updatePackageJson(
-      path.resolve(rootDir, pkg.packageDir, 'package.json'),
-      (config) => {
-        config.scripts = {}
-      },
-    )
-  })
-
   if (!process.env.CI) {
     console.warn(
       `This is a dry run for version ${version}. Push to CI to publish for real or set CI=true to override!`,
@@ -423,10 +413,23 @@ export const publish = async (options) => {
   }
 
   console.info()
+  console.info('Committing changes...')
+  execSync(`git add -A && git commit -m "${releaseCommitMsg(version)}"`)
+  console.info('  Committed Changes.')
+
+  console.info()
   console.info(`Publishing all packages to npm with tag "${npmTag}"`)
 
   // Publish each package
-  changedPackages.forEach((pkg) => {
+  changedPackages.forEach(async (pkg) => {
+    // Remove scripts section
+    await updatePackageJson(
+      path.resolve(rootDir, pkg.packageDir, 'package.json'),
+      (config) => {
+        config.scripts = {}
+      },
+    )
+
     const packageDir = path.join(rootDir, pkg.packageDir)
 
     const cmd = `cd ${packageDir} && pnpm publish --tag ${npmTag} --access=public --no-git-checks`
@@ -437,26 +440,21 @@ export const publish = async (options) => {
   })
 
   console.info()
-
-  console.info('Committing changes...')
-  execSync(`git add -A && git commit -m "${releaseCommitMsg(version)}"`)
-  console.info()
-  console.info('  Committed Changes.')
-
   console.info('Pushing changes...')
   execSync('git push')
-  console.info()
   console.info('  Changes pushed.')
 
+  console.info()
   console.info(`Creating new git tag v${version}`)
   execSync(`git tag -a -m "v${version}" v${version}`)
 
+  console.info()
   console.info('Pushing tags...')
   execSync('git push --tags')
-  console.info()
   console.info('  Tags pushed.')
 
   if (ghToken) {
+    console.info()
     console.info('Creating github release...')
 
     // Stringify the markdown to escape any quotes
@@ -469,6 +467,7 @@ export const publish = async (options) => {
     console.info('  Github release created.')
   }
 
+  console.info()
   console.info('All done!')
   return
 }


### PR DESCRIPTION
Issue noticed in https://github.com/TanStack/router/pull/1564, where the `@tanstack/config` preinstall script was running (and failing) on CI.

For all the other tanstack projects, the preinstall script is in the root workspace package.json and is not published, so no problem occurs. For this project, the root workspace package.json is the published one, and therefore gets run by anyone installing the package.

This PR clears the scripts section of packages just before the publish step. The changes are not committed (unlike the versioning changes).