### PR TITLE
fix(publish): Replace forEach loop with for/of

### DIFF
--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -419,20 +419,20 @@ export const publish = async (options) => {
 
   console.info()
   console.info('Clear package scripts...')
-  changedPackages.forEach(async (pkg) => {
+  for (const pkg of changedPackages) {
     await updatePackageJson(
       path.resolve(rootDir, pkg.packageDir, 'package.json'),
       (config) => {
         config.scripts = {}
       },
     )
-  })
+  }
 
   console.info()
   console.info(`Publishing all packages to npm with tag "${npmTag}"`)
 
   // Publish each package
-  changedPackages.forEach((pkg) => {
+  for (const pkg of changedPackages) {
     const packageDir = path.join(rootDir, pkg.packageDir)
 
     const cmd = `cd ${packageDir} && pnpm publish --tag ${npmTag} --access=public --no-git-checks`
@@ -440,7 +440,7 @@ export const publish = async (options) => {
     execSync(cmd, {
       stdio: [process.stdin, process.stdout, process.stderr],
     })
-  })
+  }
 
   console.info()
   console.info('Pushing changes...')


### PR DESCRIPTION
I fall for this async problem every time...

#85 did not remove the scripts section. By replacing the async `forEach` loops with `for...of` loops, execution order should be fixed (🤞)