### PR TITLE
refactor(publish): Remove `luxon` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/interpret": "^1.1.3",
     "@types/jsonfile": "^6.1.4",
     "@types/liftoff": "^4.0.3",
-    "@types/luxon": "^3.4.2",
     "@types/minimist": "^1.2.5",
     "@types/node": "^18.19.8",
     "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "interpret": "^3.1.1",
     "jsonfile": "^6.1.0",
     "liftoff": "^5.0.0",
-    "luxon": "^3.4.4",
     "minimist": "^1.2.8",
     "rollup-plugin-preserve-directives": "^0.4.0",
     "semver": "^7.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       '@types/liftoff':
         specifier: ^4.0.3
         version: 4.0.3
-      '@types/luxon':
-        specifier: ^3.4.2
-        version: 3.4.2
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
@@ -887,9 +884,6 @@ packages:
 
   '@types/liftoff@4.0.3':
     resolution: {integrity: sha512-UgbL2kR5pLrWICvr8+fuSg0u43LY250q7ZMkC+XKC3E+rs/YBDEnQIzsnhU5dYsLlwMi3R75UvCL87pObP1sxw==}
-
-  '@types/luxon@3.4.2':
-    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
 
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -4124,8 +4118,6 @@ snapshots:
     dependencies:
       '@types/fined': 1.1.5
       '@types/node': 18.19.8
-
-  '@types/luxon@3.4.2': {}
 
   '@types/mdast@3.0.15':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       liftoff:
         specifier: ^5.0.0
         version: 5.0.0
-      luxon:
-        specifier: ^3.4.4
-        version: 3.4.4
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -2286,10 +2283,6 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
-
-  luxon@3.4.4:
-    resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
-    engines: {node: '>=12'}
 
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
@@ -5663,8 +5656,6 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  luxon@3.4.4: {}
 
   magic-string@0.30.10:
     dependencies:

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -10,7 +10,6 @@ import currentGitBranch from 'current-git-branch'
 import { parse as parseCommit } from '@commitlint/parse'
 import log from 'git-log-parser'
 import streamToArray from 'stream-to-array'
-import { DateTime } from 'luxon'
 import {
   capitalize,
   getSorterFn,
@@ -335,9 +334,10 @@ export const publish = async (options) => {
   }
 
   const changelogMd = [
-    `Version ${version} - ${DateTime.now().toLocaleString(
-      DateTime.DATETIME_SHORT,
-    )}${tag ? ' (Manual Release)' : ''}`,
+    `Version ${version} - ${new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(Date.now())}${tag ? ' (Manual Release)' : ''}`,
     '## Changes',
     changelogCommitsMd || '- None',
     '## Packages',

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -333,11 +333,13 @@ export const publish = async (options) => {
     )
   }
 
+  const date = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(Date.now())
+
   const changelogMd = [
-    `Version ${version} - ${new Intl.DateTimeFormat(undefined, {
-      dateStyle: 'short',
-      timeStyle: 'short',
-    }).format(Date.now())}${tag ? ' (Manual Release)' : ''}`,
+    `Version ${version} - ${date}${tag ? ' (Manual Release)' : ''}`,
     '## Changes',
     changelogCommitsMd || '- None',
     '## Packages',


### PR DESCRIPTION
Within `src/publish` the largest dependency is [`luxon`](https://moment.github.io/luxon/#/). 
<img width="459" alt="src/publish package dependencies with the luxon package being the largest" src="https://github.com/TanStack/config/assets/42250071/1a92a5f9-3cd4-496b-86ae-4f08da80e903">

The `luxon` package is only used once to format the date of the change-log Markdown. 

The native [`Intl.DateTimeFormat() constructor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) can be used instead, which helps eliminate a dependency.
<img width="489" alt="New changes with native date time formatting" src="https://github.com/TanStack/config/assets/42250071/86f5944b-7595-42a8-9435-e2807fa3555d">
