### PR TITLE
fix: TS 5.5 compatibility

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -27,8 +27,7 @@ export const tanstackBuildConfig = (options) => {
         exclude: options.exclude,
         tsconfigPath: options.tsconfigPath,
         compilerOptions: {
-          // @ts-expect-error
-          module: 'esnext',
+          module: 99, // ESNext
           declarationMap: false,
         },
         beforeWriteFile: (filePath, content) => {
@@ -47,8 +46,7 @@ export const tanstackBuildConfig = (options) => {
         exclude: options.exclude,
         tsconfigPath: options.tsconfigPath,
         compilerOptions: {
-          // @ts-expect-error
-          module: 'commonjs',
+          module: 1, // CommonJS
           declarationMap: false,
         },
         beforeWriteFile: (filePath, content) => {


### PR DESCRIPTION
TS 5.5 no longer supports strings passed to `vite-plugin-dts`. This was nicer for readability.

Fixes https://github.com/TanStack/router/pull/1727

Closes #81