### PR TITLE
fix(typedoc): Disable flattenOutputFiles

### DIFF
--- a/packages/config/src/typedoc/index.js
+++ b/packages/config/src/typedoc/index.js
@@ -16,7 +16,6 @@ const settings = {
   ],
   hideGenerator: true,
   readme: 'none',
-  flattenOutputFiles: true,
   entryFileName: 'index',
   hideBreadcrumbs: true,
   hidePageHeader: true,

--- a/packages/config/src/typedoc/typedoc-custom-settings.js
+++ b/packages/config/src/typedoc/typedoc-custom-settings.js
@@ -25,13 +25,9 @@ export function load(app) {
      * @param {import("typedoc-plugin-markdown").MarkdownRendererEvent} renderer
      */ (renderer) => {
       renderer.urls = renderer.urls?.map((urlMapping) => {
-        const name = urlMapping.url.split('.')
-        if (name[0] !== 'index') {
-          name.splice(0, 1)
-        }
-        const newBasename = name.join('.')
-        urlMapping.url = newBasename
-        urlMapping.model.url = newBasename
+        const name = urlMapping.url.toLowerCase()
+        urlMapping.url = name
+        urlMapping.model.url = name
         return urlMapping
       })
     },


### PR DESCRIPTION
As discussed on Discord
Now lowercase file names don't override each other :)