### PR TITLE
feat: use main branch on typedoc links

### DIFF
--- a/packages/config/src/typedoc/index.js
+++ b/packages/config/src/typedoc/index.js
@@ -21,6 +21,7 @@ const settings = {
   hidePageHeader: true,
   useCodeBlocks: true,
   excludePrivate: true,
+  gitRevision: 'main',
 }
 
 /**


### PR DESCRIPTION
By default typedoc uses the hash of the latest commit, this means that generating the docs again after a commit updates all files to set the new hash.

See: https://github.com/TanStack/form/commit/ec7360c773b360e51c074b57ef2f1e0f6b841dfa

With this change the link uses `main` so only effectively changes interfaces generate an update.