### PR TITLE
feat(typedoc): allow customising branch in GitHub link

### DIFF
--- a/packages/config/src/typedoc/index.d.ts
+++ b/packages/config/src/typedoc/index.d.ts
@@ -11,6 +11,7 @@ export type Package = {
 export type Options = {
   /** Config for packages that need reference docs */
   packages: Array<Package>
+  gitBranch?: string
 }
 
 export function generateReferenceDocs(config: Options): Promise<void>

--- a/packages/config/src/typedoc/index.d.ts
+++ b/packages/config/src/typedoc/index.d.ts
@@ -11,6 +11,7 @@ export type Package = {
 export type Options = {
   /** Config for packages that need reference docs */
   packages: Array<Package>
+  /** Override branch for GitHub links */
   gitBranch?: string
 }
 

--- a/packages/config/src/typedoc/index.js
+++ b/packages/config/src/typedoc/index.js
@@ -42,6 +42,7 @@ export const generateReferenceDocs = async (options) => {
 
     const app = await TypeDoc.Application.bootstrapWithPlugins({
       ...settings,
+      gitRevision: options.gitBranch ?? 'main',
       entryPoints: pkg.entryPoints,
       tsconfig: pkg.tsconfig,
       exclude: pkg.exclude,


### PR DESCRIPTION
Alternative to #150 

Means that docs for older versions (e.g. Query v4) can still generate links to that version's source