### PR TITLE
fix(vite): downgrade vite-plugin-dts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,5 @@
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["pnpmDedupe"],
-  "ignoreDeps": ["@types/node", "node", "typescript"]
+  "ignoreDeps": ["@types/node", "node", "typescript", "vite-plugin-dts"]
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -80,7 +80,7 @@
     "typedoc-plugin-markdown": "^4.2.7",
     "typescript-eslint": "^8.5.0",
     "v8flags": "^4.0.1",
-    "vite-plugin-dts": "^4.2.1",
+    "vite-plugin-dts": "4.0.3",
     "vite-plugin-externalize-deps": "^0.8.0",
     "vite-tsconfig-paths": "^5.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       vite-plugin-dts:
-        specifier: ^4.2.1
-        version: 4.2.1(@types/node@20.16.5)(rollup@4.21.3)(typescript@5.6.2)(vite@5.4.5(@types/node@20.16.5))
+        specifier: 4.0.3
+        version: 4.0.3(@types/node@20.16.5)(rollup@4.21.3)(typescript@5.6.2)(vite@5.4.5(@types/node@20.16.5))
       vite-plugin-externalize-deps:
         specifier: ^0.8.0
         version: 0.8.0(vite@5.4.5(@types/node@20.16.5))
@@ -500,11 +500,11 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@microsoft/api-extractor-model@7.29.6':
-    resolution: {integrity: sha512-gC0KGtrZvxzf/Rt9oMYD2dHvtN/1KPEYsrQPyMKhLHnlVuO/f4AFN3E4toqZzD2pt4LhkKoYmL2H9tX3yCOyRw==}
+  '@microsoft/api-extractor-model@7.29.4':
+    resolution: {integrity: sha512-LHOMxmT8/tU1IiiiHOdHFF83Qsi+V8d0kLfscG4EvQE9cafiR8blOYr8SfkQKWB1wgEilQgXJX3MIA4vetDLZw==}
 
-  '@microsoft/api-extractor@7.47.7':
-    resolution: {integrity: sha512-fNiD3G55ZJGhPOBPMKD/enozj8yxJSYyVJWxRWdcUtw842rvthDHJgUWq9gXQTensFlMHv2wGuCjjivPv53j0A==}
+  '@microsoft/api-extractor@7.47.4':
+    resolution: {integrity: sha512-HKm+P4VNzWwvq1Ey+Jfhhj/3MjsD+ka2hbt8L5AcRM95lu1MFOYnz3XlU7Gr79Q/ZhOb7W/imAKeYrOI0bFydg==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.17.0':
@@ -681,8 +681,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rushstack/node-core-library@5.7.0':
-    resolution: {integrity: sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==}
+  '@rushstack/node-core-library@5.5.1':
+    resolution: {integrity: sha512-ZutW56qIzH8xIOlfyaLQJFx+8IBqdbVCZdnj+XT1MorQ1JqqxHse8vbCpEM+2MjsrqcbxcgDIbfggB1ZSQ2A3g==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -692,16 +692,16 @@ packages:
   '@rushstack/rig-package@0.5.3':
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.14.0':
-    resolution: {integrity: sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==}
+  '@rushstack/terminal@0.13.3':
+    resolution: {integrity: sha512-fc3zjXOw8E0pXS5t9vTiIPx9gHA0fIdTXsu9mT4WbH+P3mYvnrX0iAQ5a6NvyK1+CqYWBTw/wVNx7SDJkI+WYQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@4.22.6':
-    resolution: {integrity: sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==}
+  '@rushstack/ts-command-line@4.22.3':
+    resolution: {integrity: sha512-edMpWB3QhFFZ4KtSzS8WNjBgR4PXPPOVrOHMbb7kNpmQ1UFS9HdVtjCXg1H5fG+xYAbeE+TMPcVPUyX2p84STA==}
 
   '@shikijs/core@1.17.7':
     resolution: {integrity: sha512-ZnIDxFu/yvje3Q8owSHaEHd+bu/jdWhHAaJ17ggjXofHx5rc4bhpCSW+OjC6smUBi5s5dd023jWtZ1gzMu/yrw==}
@@ -932,8 +932,8 @@ packages:
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
 
-  '@vue/language-core@2.1.6':
-    resolution: {integrity: sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==}
+  '@vue/language-core@2.0.29':
+    resolution: {integrity: sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2619,8 +2619,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-plugin-dts@4.2.1:
-    resolution: {integrity: sha512-/QlYvgUMiv8+ZTEerhNCYnYaZMM07cdlX6hQCR/w/g/nTh0tUXPoYwbT6SitizLJ9BybT1lnrcZgqheI6wromQ==}
+  vite-plugin-dts@4.0.3:
+    resolution: {integrity: sha512-+xnTsaONwU2kV6zhRjtbRJSGN41uFR/whqmcb4k4fftLFDJElxthp0PP5Fq8gMeM9ytWMt1yk5gGgekLREWYQQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -2700,6 +2700,12 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  vue-tsc@2.0.29:
+    resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.6:
     resolution: {integrity: sha512-zv+20E2VIYbcJOzJPUWp03NOGFhMmpCKOfSxVTmCYyYFFko48H9tmuQFzYj7tu4qX1AeXlp9DmhIP89/sSxxhw==}
@@ -3103,23 +3109,23 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@microsoft/api-extractor-model@7.29.6(@types/node@20.16.5)':
+  '@microsoft/api-extractor-model@7.29.4(@types/node@20.16.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.7.0(@types/node@20.16.5)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.16.5)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.7(@types/node@20.16.5)':
+  '@microsoft/api-extractor@7.47.4(@types/node@20.16.5)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.6(@types/node@20.16.5)
+      '@microsoft/api-extractor-model': 7.29.4(@types/node@20.16.5)
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.7.0(@types/node@20.16.5)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.16.5)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.0(@types/node@20.16.5)
-      '@rushstack/ts-command-line': 4.22.6(@types/node@20.16.5)
+      '@rushstack/terminal': 0.13.3(@types/node@20.16.5)
+      '@rushstack/ts-command-line': 4.22.3(@types/node@20.16.5)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -3251,7 +3257,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.21.3':
     optional: true
 
-  '@rushstack/node-core-library@5.7.0(@types/node@20.16.5)':
+  '@rushstack/node-core-library@5.5.1(@types/node@20.16.5)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -3269,16 +3275,16 @@ snapshots:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.0(@types/node@20.16.5)':
+  '@rushstack/terminal@0.13.3(@types/node@20.16.5)':
     dependencies:
-      '@rushstack/node-core-library': 5.7.0(@types/node@20.16.5)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.16.5)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.16.5
 
-  '@rushstack/ts-command-line@4.22.6(@types/node@20.16.5)':
+  '@rushstack/ts-command-line@4.22.3(@types/node@20.16.5)':
     dependencies:
-      '@rushstack/terminal': 0.14.0(@types/node@20.16.5)
+      '@rushstack/terminal': 0.13.3(@types/node@20.16.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -3596,7 +3602,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.1.6(typescript@5.6.2)':
+  '@vue/language-core@2.0.29(typescript@5.6.2)':
     dependencies:
       '@volar/language-core': 2.4.5
       '@vue/compiler-dom': 3.5.6
@@ -5327,18 +5333,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.2.1(@types/node@20.16.5)(rollup@4.21.3)(typescript@5.6.2)(vite@5.4.5(@types/node@20.16.5)):
+  vite-plugin-dts@4.0.3(@types/node@20.16.5)(rollup@4.21.3)(typescript@5.6.2)(vite@5.4.5(@types/node@20.16.5)):
     dependencies:
-      '@microsoft/api-extractor': 7.47.7(@types/node@20.16.5)
+      '@microsoft/api-extractor': 7.47.4(@types/node@20.16.5)
       '@rollup/pluginutils': 5.1.0(rollup@4.21.3)
       '@volar/typescript': 2.4.5
-      '@vue/language-core': 2.1.6(typescript@5.6.2)
+      '@vue/language-core': 2.0.29(typescript@5.6.2)
       compare-versions: 6.1.1
       debug: 4.3.7
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.11
       typescript: 5.6.2
+      vue-tsc: 2.0.29(typescript@5.6.2)
     optionalDependencies:
       vite: 5.4.5(@types/node@20.16.5)
     transitivePeerDependencies:
@@ -5406,6 +5413,13 @@ snapshots:
       - terser
 
   vscode-uri@3.0.8: {}
+
+  vue-tsc@2.0.29(typescript@5.6.2):
+    dependencies:
+      '@volar/typescript': 2.4.5
+      '@vue/language-core': 2.0.29(typescript@5.6.2)
+      semver: 7.6.3
+      typescript: 5.6.2
 
   vue@3.5.6(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
Fixes build-only type issues in TanStack Router repo. For example, `@tanstack/start-vite-plugin`:

vite-plugin-dts 4.1.0:

```
vite v5.4.5 building for production...
src/index.ts:3:15 - error TS2305: Module '"../../../node_modules/vite/index.cjs"' has no exported member 'Plugin'.

3 import type { Plugin } from 'vite'
                ~~~~~~
src/index.ts:17:22 - error TS7006: Parameter 'config' implicitly has an 'any' type.

17     configResolved: (config) => {
                        ~~~~~~
src/index.ts:20:15 - error TS7006: Parameter 'code' implicitly has an 'any' type.

20     transform(code, id) {
                 ~~~~
src/index.ts:20:21 - error TS7006: Parameter 'id' implicitly has an 'any' type.

20     transform(code, id) {
                       ~~

Please fix the above type errors
 ELIFECYCLE  Command failed with exit code 1.
```

vite-plugin-dts 4.0.3:

```
vite v5.4.5 building for production...
✓ 3 modules transformed.

[vite:dts] Start generate declaration files...

[vite:dts] Start generate declaration files... (x2)
dist/esm/ast.js        0.82 kB │ gzip: 0.34 kB │ map: 1.48 kB
dist/esm/index.js      1.74 kB │ gzip: 0.71 kB │ map: 2.76 kB
dist/esm/compilers.js  4.33 kB │ gzip: 1.16 kB │ map: 8.33 kB
[vite:dts] Declaration files built in 1804ms.

[vite:dts] Declaration files built in 790ms.

dist/cjs/ast.cjs        1.44 kB │ gzip: 0.59 kB │ map: 1.51 kB
dist/cjs/index.cjs      1.88 kB │ gzip: 0.77 kB │ map: 2.84 kB
dist/cjs/compilers.cjs  5.37 kB │ gzip: 1.41 kB │ map: 8.42 kB
✓ built in 1.90s
```