### PR TITLE
fix: ignore temporary vite config files

### DIFF
--- a/packages/config/src/eslint/index.js
+++ b/packages/config/src/eslint/index.js
@@ -18,6 +18,7 @@ const GLOB_EXCLUDE = [
   '**/coverage/**',
   '**/dist/**',
   '**/snap/**',
+  '**/vite.config.*.timestamp-*.*'
 ]
 
 /** @type {import('eslint').Linter.Config[]} */

--- a/packages/config/src/eslint/index.js
+++ b/packages/config/src/eslint/index.js
@@ -18,7 +18,7 @@ const GLOB_EXCLUDE = [
   '**/coverage/**',
   '**/dist/**',
   '**/snap/**',
-  '**/vite.config.*.timestamp-*.*'
+  '**/vite.config.*.timestamp-*.*',
 ]
 
 /** @type {import('eslint').Linter.Config[]} */


### PR DESCRIPTION
otherwise eslint might trip over such temp file like this:

Error: ENOENT: no such file or directory, open '/home/workflows/workspace/packages/react-router/vite.config.ts.timestamp-1727808513722-641dfc845ba89.mjs'