### PR TITLE
fix: updates imports that are more than one parent high

### DIFF
--- a/packages/config/src/vite/index.js
+++ b/packages/config/src/vite/index.js
@@ -13,13 +13,13 @@ import dts from 'vite-plugin-dts'
 function ensureImportFileExtension({ content, extension }) {
   // replace e.g. `import { foo } from './foo'` with `import { foo } from './foo.js'`
   content = content.replace(
-    /(im|ex)port\s[\w{}/*\s,]+from\s['"]\.\.?\/[^.'"]+(?=['"];?)/gm,
+    /(im|ex)port\s[\w{}/*\s,]+from\s['"](?:\.\.?\/)+?[^.'"]+(?=['"];?)/gm,
     `$&.${extension}`,
   )
 
   // replace e.g. `import('./foo')` with `import('./foo.js')`
   content = content.replace(
-    /import\(['"]\.\.?\/[^.'"]+(?=['"];?)/gm,
+    /import\(['"](?:\.\.?\/)+?[^.'"]+(?=['"];?)/gm,
     `$&.${extension}`,
   )
   return content


### PR DESCRIPTION
I noticed that `../../test` wasn't being transformed in the `.cjs` or `.js` import changer. This fixes that