### PR TITLE
fix: @stylistic/eslint-plugin-js to @stylistic/eslint-plugin

### DIFF
--- a/.changeset/afraid-states-reply.md
+++ b/.changeset/afraid-states-reply.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/eslint-config': minor
+---
+
+@stylistic/eslint-plugin-js to @stylistic/eslint-plugin as eslint-plugin-js is now deprecated

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@eslint/js": "catalog:",
-    "@stylistic/eslint-plugin-js": "catalog:",
+    "@stylistic/eslint-plugin": "catalog:",
     "eslint-plugin-import-x": "catalog:",
     "eslint-plugin-n": "catalog:",
     "globals": "catalog:",

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -1,6 +1,6 @@
 import tseslint from 'typescript-eslint'
 import vueparser from 'vue-eslint-parser'
-import stylisticJs from '@stylistic/eslint-plugin-js'
+import stylisticJs from '@stylistic/eslint-plugin'
 import pluginImport from 'eslint-plugin-import-x'
 import pluginNode from 'eslint-plugin-n'
 import globals from 'globals'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ catalogs:
     '@eslint/js':
       specifier: ^9.27.0
       version: 9.27.0
-    '@stylistic/eslint-plugin-js':
+    '@stylistic/eslint-plugin':
       specifier: ^4.4.0
       version: 4.4.0
     '@svitejs/changesets-changelog-github-compact':
@@ -254,9 +254,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.27.0
-      '@stylistic/eslint-plugin-js':
+      '@stylistic/eslint-plugin':
         specifier: 'catalog:'
-        version: 4.4.0(eslint@9.27.0)
+        version: 4.4.0(eslint@9.27.0)(typescript@5.8.3)
       eslint-plugin-import-x:
         specifier: 'catalog:'
         version: 4.13.3(eslint@9.27.0)(typescript@5.8.3)
@@ -1017,8 +1017,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@stylistic/eslint-plugin-js@4.4.0':
-    resolution: {integrity: sha512-UeeQNRF73zJXnNGGbvwgUgzS+vzVGQoRuQKR6RhQCRHQmaBaVHxDDQVmN9RPLCnRxVjO/v8cqq/yMDqC7DikSQ==}
+  '@stylistic/eslint-plugin@4.4.0':
+    resolution: {integrity: sha512-bIh/d9X+OQLCAMdhHtps+frvyjvAM4B1YlSJzcEEhl7wXLIqPar3ngn9DrHhkBOrTA/z9J0bUMtctAspe0dxdQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
@@ -3783,11 +3783,17 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@stylistic/eslint-plugin-js@4.4.0(eslint@9.27.0)':
+  '@stylistic/eslint-plugin@4.4.0(eslint@9.27.0)(typescript@5.8.3)':
     dependencies:
+      '@typescript-eslint/utils': 8.32.1(eslint@9.27.0)(typescript@5.8.3)
       eslint: 9.27.0
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
+      estraverse: 5.3.0
+      picomatch: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@svitejs/changesets-changelog-github-compact@1.2.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ catalog:
   '@changesets/cli': ^2.29.4
   '@commitlint/parse': ^19.8.1
   '@eslint/js': ^9.27.0
-  '@stylistic/eslint-plugin-js': ^4.4.0
+  '@stylistic/eslint-plugin': ^4.4.0
   '@svitejs/changesets-changelog-github-compact': ^1.2.0
   '@tanstack/query-core': ^5.77.2
   '@types/eslint': ^9.6.1


### PR DESCRIPTION

![Screenshot 2025-05-30 at 1 05 42 AM](https://github.com/user-attachments/assets/6df7c8e9-bee8-4d2a-b5d9-a2ae15011d48)

- [@stylistic/eslint-plugin-js](https://eslint.style/packages/js) is now deprecated in favour of unified [@stylistic/eslint-plugin](https://eslint.style/packages/default)

![Screenshot 2025-05-30 at 1 07 03 AM](https://github.com/user-attachments/assets/c33dcb45-2f22-4b81-a39a-fac1632b520c)

- the PR makes the transition for the same

![Screenshot 2025-05-30 at 1 03 19 AM](https://github.com/user-attachments/assets/9d4cc11c-5bae-4ef8-89f2-0c09c39b5cf5)
