### PR TITLE
fix(publish): use 'previous' npm tag for old releases

### DIFF
--- a/.changeset/giant-wombats-sneeze.md
+++ b/.changeset/giant-wombats-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/publish-config': patch
+---
+
+fix(publish): use 'previous' npm tag for old releases

--- a/packages/publish-config/src/index.js
+++ b/packages/publish-config/src/index.js
@@ -48,6 +48,7 @@ export const publish = async (options) => {
   const { branchConfigs, packages, rootDir, branch, tag, ghToken } = options
 
   const branchName = /** @type {string} */ (branch ?? currentGitBranch())
+  const isMainBranch = branchName === 'main'
 
   /** @type {import('./index.js').BranchConfig | undefined} */
   const branchConfig = branchConfigs[branchName]
@@ -55,8 +56,6 @@ export const publish = async (options) => {
   if (!branchConfig) {
     throw new Error(`No publish config found for branch: ${branchName}`)
   }
-
-  const isMainBranch = branchName === 'main'
 
   // Get tags
   /** @type {string[]} */


### PR DESCRIPTION
I'm surprised we haven't run into this problem before. Old releases don't currently work, as npm won't allow tags that match semver:

`npm error Tag name must not be a valid SemVer range: v4`

This PR marks old branches with the tag `previous`. This is similar to the strategy used by Vite: https://www.npmjs.com/package/vite?activeTab=versions