### PR TITLE
fix(publish): do not remove package scripts

### DIFF
--- a/.changeset/eleven-clowns-create.md
+++ b/.changeset/eleven-clowns-create.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/config': minor
+'@tanstack/publish-config': minor
+---
+
+don't remove package scripts before publish

--- a/packages/publish-config/src/index.js
+++ b/packages/publish-config/src/index.js
@@ -443,17 +443,6 @@ export const publish = async (options) => {
   execSync(`git add -A && git commit -m "${releaseCommitMsg(version)}"`)
   console.info('  Committed Changes.')
 
-  console.info()
-  console.info('Clear package scripts...')
-  for (const pkg of changedPackages) {
-    await updatePackageJson(
-      path.resolve(rootDir, pkg.packageDir, 'package.json'),
-      (config) => {
-        config.scripts = {}
-      },
-    )
-  }
-
   /** 'latest' for current version, 'previous' for old versions, and custom for prereleases */
   const npmTag = isMainBranch
     ? 'latest'


### PR DESCRIPTION
In @tanstack/angular-query I need to run a `prepack` lifecycle script.

Currently, the publish script removes all scripts before publishing.