### PR TITLE
Update sidebar link to fix 404

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -36,8 +36,8 @@
       "label": "Conventions",
       "children": [
         {
-          "label": "Nx",
-          "to": "nx"
+          "label": "CI/CD",
+          "to": "ci-cd"
         },
         {
           "label": "Package Structure",


### PR DESCRIPTION
<img width="1259" height="831" alt="SCR-20250801-enuf" src="https://github.com/user-attachments/assets/14e3e5da-3ad8-4352-ad8f-5686a31538f6" />

https://tanstack.com/config/latest/docs/nx returns a 404. After investigating, I realized that it was most likely due to the nx doc being updated and then expanded into the CI/CD doc. This is a very small update to instead point to the newer CI/CD doc, of which contains an nx section. 
