### PR TITLE
ci: disable caching in `actions/setup-node`

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -9,6 +9,7 @@ runs:
       uses: actions/setup-node@v5.0.0
       with:
         node-version-file: .nvmrc
+        package-manager-cache: false
     - name: Get pnpm store directory
       shell: bash
       run: |


### PR DESCRIPTION
## 🎯 Changes

Turns out https://github.com/actions/setup-node/releases/tag/v5.0.0 enabled caching by default. So workflows have been double-downloading and double-uploading caches. This returns it to a normal amount of cache :)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
