### PR TITLE
New oxlint-config package

### DIFF
--- a/.changeset/gentle-cases-allow.md
+++ b/.changeset/gentle-cases-allow.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/oxlint-config': minor
+---
+
+Release @tanstack/oxlint-config

--- a/packages/oxlint-config/oxlint.config.ts
+++ b/packages/oxlint-config/oxlint.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'oxlint'
+import { tanstackConfig } from '@tanstack/oxlint-config'
+
+export default defineConfig({
+  extends: [tanstackConfig],
+})

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/oxlint-config",
-  "version": "0.3.4",
-  "description": "Shared oxlint config used by TanStack projects.",
+  "version": "0.1.0",
+  "description": "Oxlint config based on @tanstack/eslint-config",
   "author": "tannerlinsley",
   "license": "MIT",
   "repository": {

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@tanstack/oxlint-config",
+  "version": "0.3.4",
+  "description": "Shared oxlint config used by TanStack projects.",
+  "author": "tannerlinsley",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/config.git",
+    "directory": "packages/oxlint-config"
+  },
+  "homepage": "https://tanstack.com/config",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "scripts": {
+    "test:types": "tsc",
+    "test:eslint": "oxlint ./src",
+    "build": "tsdown"
+  },
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "preferGlobal": false,
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@stylistic/eslint-plugin": "catalog:",
+    "oxlint": "catalog:"
+  },
+  "peerDependencies": {
+    "oxlint": "^1.0.0"
+  }
+}

--- a/packages/oxlint-config/src/import.ts
+++ b/packages/oxlint-config/src/import.ts
@@ -1,0 +1,37 @@
+import type { OxlintConfig } from 'oxlint'
+
+export const importConfig: OxlintConfig = {
+  plugins: ['import'],
+  rules: {
+    /** Bans the use of inline type-only markers for named imports */
+    'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+    /** Reports any imports that come after non-import statements */
+    'import/first': 'error',
+
+    /** Stylistic preference */
+    // 'import/newline-after-import': 'error', // No implementation yet / unsupported
+
+    /** No require() or module.exports */
+    'import/no-commonjs': 'error',
+    /** Reports if a resolved path is imported more than once */
+    'import/no-duplicates': 'error',
+
+    /** Stylistic preference */
+    // // No implementation yet / unsupported
+    // 'import/order': [
+    //   'error',
+    //   {
+    //     groups: [
+    //       'builtin',
+    //       'external',
+    //       'internal',
+    //       'parent',
+    //       'sibling',
+    //       'index',
+    //       'object',
+    //       'type',
+    //     ],
+    //   },
+    // ],
+  },
+}

--- a/packages/oxlint-config/src/index.ts
+++ b/packages/oxlint-config/src/index.ts
@@ -1,0 +1,33 @@
+import type { OxlintConfig } from 'oxlint'
+import { defineConfig } from 'oxlint'
+import { javascriptConfig } from './javascript.ts'
+import { importConfig } from './import.ts'
+import { typescriptConfig } from './typescript.ts'
+import { nodeConfig } from './node.ts'
+import { stylisticConfig } from './stylistic.ts'
+
+const GLOB_EXCLUDE = [
+  '**/.nx/**',
+  '**/.svelte-kit/**',
+  '**/build/**',
+  '**/coverage/**',
+  '**/dist/**',
+  '**/snap/**',
+  '**/vite.config.*.timestamp-*.*',
+]
+
+export const tanstackConfig: OxlintConfig = defineConfig({
+  extends: [
+    javascriptConfig,
+    typescriptConfig,
+    importConfig,
+    nodeConfig,
+    stylisticConfig,
+  ],
+  env: {
+    builtin: true,
+    es2020: true,
+    browser: true,
+  },
+  ignorePatterns: GLOB_EXCLUDE,
+})

--- a/packages/oxlint-config/src/javascript.ts
+++ b/packages/oxlint-config/src/javascript.ts
@@ -1,0 +1,57 @@
+import type { OxlintConfig } from 'oxlint'
+
+export const javascriptConfig: OxlintConfig = {
+  rules: {
+    /** TODO */
+    'for-direction': 'error',
+    'no-async-promise-executor': 'error',
+    'no-case-declarations': 'error',
+    'no-class-assign': 'error',
+    'no-compare-neg-zero': 'error',
+    'no-cond-assign': 'error',
+    'no-constant-binary-expression': 'error',
+    'no-constant-condition': 'error',
+    'no-control-regex': 'error',
+    'no-debugger': 'error',
+    'no-delete-var': 'error',
+    'no-dupe-else-if': 'error',
+    'no-duplicate-case': 'error',
+    'no-empty-character-class': 'error',
+    'no-empty-pattern': 'error',
+    'no-empty-static-block': 'error',
+    'no-ex-assign': 'error',
+    'no-extra-boolean-cast': 'error',
+    'no-fallthrough': 'error',
+    'no-global-assign': 'error',
+    'no-invalid-regexp': 'error',
+    'no-irregular-whitespace': 'error',
+    'no-loss-of-precision': 'error',
+    'no-misleading-character-class': 'error',
+    'no-nonoctal-decimal-escape': 'error',
+    // 'no-octal': 'error', // No implementation yet / unsupported
+    'no-regex-spaces': 'error',
+    'no-self-assign': 'error',
+    /** Warn about variable with identical names in the outer scope */
+    // 'no-shadow': 'warn', // No implementation yet / unsupported
+    'no-shadow-restricted-names': 'error',
+    'no-sparse-arrays': 'error',
+    'no-unsafe-finally': 'error',
+    'no-unsafe-optional-chaining': 'error',
+    'no-unused-labels': 'error',
+    'no-unused-private-class-members': 'error',
+    'no-useless-backreference': 'error',
+    'no-useless-catch': 'error',
+    'no-useless-escape': 'error',
+    /** Prefer let and const */
+    'no-var': 'error',
+    'no-with': 'error',
+    /** Prefer const if never re-assigned */
+    'prefer-const': 'error',
+    'require-yield': 'error',
+    /** Stylistic consistency */
+    'sort-imports': ['error', { ignoreDeclarationSort: true }],
+    'use-isnan': 'error',
+    /** Enforce comparing typeof against valid strings */
+    'valid-typeof': 'error',
+  },
+}

--- a/packages/oxlint-config/src/javascript.ts
+++ b/packages/oxlint-config/src/javascript.ts
@@ -28,11 +28,10 @@ export const javascriptConfig: OxlintConfig = {
     'no-loss-of-precision': 'error',
     'no-misleading-character-class': 'error',
     'no-nonoctal-decimal-escape': 'error',
-    // 'no-octal': 'error', // No implementation yet / unsupported
     'no-regex-spaces': 'error',
     'no-self-assign': 'error',
     /** Warn about variable with identical names in the outer scope */
-    // 'no-shadow': 'warn', // No implementation yet / unsupported
+    // 'no-shadow': 'warn', // No implementation yet
     'no-shadow-restricted-names': 'error',
     'no-sparse-arrays': 'error',
     'no-unsafe-finally': 'error',

--- a/packages/oxlint-config/src/node.ts
+++ b/packages/oxlint-config/src/node.ts
@@ -1,0 +1,9 @@
+import type { OxlintConfig } from 'oxlint'
+
+export const nodeConfig: OxlintConfig = {
+  plugins: ['unicorn'],
+  rules: {
+    /** Enforce usage of the `node:` prefix for builtin imports */
+    'unicorn/prefer-node-protocol': 'error',
+  },
+}

--- a/packages/oxlint-config/src/stylistic.ts
+++ b/packages/oxlint-config/src/stylistic.ts
@@ -1,0 +1,9 @@
+import type { OxlintConfig } from 'oxlint'
+
+export const stylisticConfig: OxlintConfig = {
+  jsPlugins: [{ name: '@stylistic', specifier: '@stylistic/eslint-plugin' }],
+  rules: {
+    /** Enforce consistency of spacing after the start of a comment */
+    '@stylistic/spaced-comment': 'error',
+  },
+}

--- a/packages/oxlint-config/src/typescript.ts
+++ b/packages/oxlint-config/src/typescript.ts
@@ -22,10 +22,10 @@ export const typescriptConfig: OxlintConfig = {
       { prefer: 'type-imports' },
     ],
     /** Shorthand method style is less strict */
-    // '@typescript-eslint/method-signature-style': ['error', 'property'], // No implemented yet / unsuppported
+    // '@typescript-eslint/method-signature-style': ['error', 'property'], // No implemented yet
 
     /** Enforces generic type convention */
-    // // Not implemented yet / unsupported
+    // // Not implemented yet
     // '@typescript-eslint/naming-convention': [
     //   'error',
     //   {

--- a/packages/oxlint-config/src/typescript.ts
+++ b/packages/oxlint-config/src/typescript.ts
@@ -1,0 +1,84 @@
+import type { OxlintConfig } from 'oxlint'
+
+export const typescriptConfig: OxlintConfig = {
+  plugins: ['typescript'],
+  rules: {
+    /** Prefer Array<T> format */
+    '@typescript-eslint/array-type': [
+      'error',
+      { default: 'generic', readonly: 'generic' },
+    ],
+    /** Prevent @ts-ignore, allow @ts-expect-error */
+    '@typescript-eslint/ban-ts-comment': [
+      'error',
+      {
+        'ts-expect-error': false,
+        'ts-ignore': 'allow-with-description',
+      },
+    ],
+    /** Enforce import type { T } */
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { prefer: 'type-imports' },
+    ],
+    /** Shorthand method style is less strict */
+    // '@typescript-eslint/method-signature-style': ['error', 'property'], // No implemented yet / unsuppported
+
+    /** Enforces generic type convention */
+    // // Not implemented yet / unsupported
+    // '@typescript-eslint/naming-convention': [
+    //   'error',
+    //   {
+    //     selector: 'typeParameter',
+    //     format: ['PascalCase'],
+    //     leadingUnderscore: 'forbid',
+    //     trailingUnderscore: 'forbid',
+    //     custom: {
+    //       regex: '^(T|T[A-Z][A-Za-z]+)$',
+    //       match: true,
+    //     },
+    //   },
+    // ],
+
+    /** Duplicate values can lead to bugs that are hard to track down */
+    '@typescript-eslint/no-duplicate-enum-values': 'error',
+    /** Using the operator any more than once does nothing */
+    '@typescript-eslint/no-extra-non-null-assertion': 'error',
+
+    /** There are several potential bugs with this compared to other loops */
+    // '@typescript-eslint/no-for-in-array': 'error', // Requires TypeScript-native (tsgo)
+
+    /** Don't over-define types for simple things like strings */
+    '@typescript-eslint/no-inferrable-types': [
+      'error',
+      { ignoreParameters: true },
+    ],
+    /** Enforce valid definition of new and constructor */
+    '@typescript-eslint/no-misused-new': 'error',
+    /** Disallow TypeScript namespaces */
+    '@typescript-eslint/no-namespace': 'error',
+    /** Disallow non-null assertions after an optional chain expression */
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+
+    /** Detects conditionals which will always evaluate truthy or falsy */
+    // '@typescript-eslint/no-unnecessary-condition': 'error', // Not implemented yet / unsupported
+
+    /** Checks if the the explicit type is identical to the inferred type */
+    // '@typescript-eslint/no-unnecessary-type-assertion': 'error', // Requires TypeScript-native (tsgo)
+
+    /** Disallow using the unsafe built-in Function type */
+    '@typescript-eslint/no-unsafe-function-type': 'error',
+    /** Disallow using confusing built-in primitive class wrappers */
+    '@typescript-eslint/no-wrapper-object-types': 'error',
+    /** Enforce the use of as const over literal type */
+    '@typescript-eslint/prefer-as-const': 'error',
+    /** Prefer for-of loop over the standard for loop */
+    '@typescript-eslint/prefer-for-of': 'warn',
+
+    /** Warn about async functions which have no await expression */
+    // '@typescript-eslint/require-await': 'warn', // Requires TypeScript-native (tsgo)
+
+    /** Prefer of ES6-style import declarations */
+    '@typescript-eslint/triple-slash-reference': 'error',
+  },
+}

--- a/packages/oxlint-config/tsconfig.json
+++ b/packages/oxlint-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "isolatedDeclarations": true
+  },
+  "include": ["src"]
+}

--- a/packages/oxlint-config/tsdown.config.ts
+++ b/packages/oxlint-config/tsdown.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  format: ['esm'],
+  platform: 'node',
+  unbundle: true,
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  fixedExtension: false,
+  exports: {
+    devExports: true,
+  },
+  publint: {
+    strict: true,
+  },
+  attw: {
+    profile: 'esm-only',
+    level: 'error',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ catalogs:
     nx:
       specifier: 22.5.0
       version: 22.5.0
+    oxlint:
+      specifier: ^1.47.0
+      version: 1.47.0
     premove:
       specifier: ^4.0.0
       version: 4.0.0
@@ -299,6 +302,15 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.0.0(jiti@2.6.1)
+
+  packages/oxlint-config:
+    dependencies:
+      '@stylistic/eslint-plugin':
+        specifier: 'catalog:'
+        version: 5.7.1(eslint@10.0.0(jiti@2.6.1))
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.47.0
 
   packages/publish-config:
     dependencies:
@@ -977,6 +989,128 @@ packages:
 
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
+
+  '@oxlint/binding-android-arm-eabi@1.47.0':
+    resolution: {integrity: sha512-UHqo3te9K/fh29brCuQdHjN+kfpIi9cnTPABuD5S9wb9ykXYRGTOOMVuSV/CK43sOhU4wwb2nT1RVjcbrrQjFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.47.0':
+    resolution: {integrity: sha512-xh02lsTF1TAkR+SZrRMYHR/xCx8Wg2MAHxJNdHVpAKELh9/yE9h4LJeqAOBbIb3YYn8o/D97U9VmkvkfJfrHfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.47.0':
+    resolution: {integrity: sha512-OSOfNJqabOYbkyQDGT5pdoL+05qgyrmlQrvtCO58M4iKGEQ/xf3XkkKj7ws+hO+k8Y4VF4zGlBsJlwqy7qBcHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.47.0':
+    resolution: {integrity: sha512-hP2bOI4IWNS+F6pVXWtRshSTuJ1qCRZgDgVUg6EBUqsRy+ExkEPJkx+YmIuxgdCduYK1LKptLNFuQLJP8voPbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.47.0':
+    resolution: {integrity: sha512-F55jIEH5xmGu7S661Uho8vGiLFk0bY3A/g4J8CTKiLJnYu/PSMZ2WxFoy5Hji6qvFuujrrM9Q8XXbMO0fKOYPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.47.0':
+    resolution: {integrity: sha512-wxmOn/wns/WKPXUC1fo5mu9pMZPVOu8hsynaVDrgmmXMdHKS7on6bA5cPauFFN9tJXNdsjW26AK9lpfu3IfHBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.47.0':
+    resolution: {integrity: sha512-KJTmVIA/GqRlM2K+ZROH30VMdydEU7bDTY35fNg3tOPzQRIs2deLZlY/9JWwdWo1F/9mIYmpbdCmPqtKhWNOPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.47.0':
+    resolution: {integrity: sha512-PF7ELcFg1GVlS0X0ZB6aWiXobjLrAKer3T8YEkwIoO8RwWiAMkL3n3gbleg895BuZkHVlJ2kPRUwfrhHrVkD1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.47.0':
+    resolution: {integrity: sha512-4BezLRO5cu0asf0Jp1gkrnn2OHiXrPPPEfBTxq1k5/yJ2zdGGTmZxHD2KF2voR23wb8Elyu3iQawXo7wvIZq0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.47.0':
+    resolution: {integrity: sha512-aI5ds9jq2CPDOvjeapiIj48T/vlWp+f4prkxs+FVzrmVN9BWIj0eqeJ/hV8WgXg79HVMIz9PU6deI2ki09bR1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.47.0':
+    resolution: {integrity: sha512-mO7ycp9Elvgt5EdGkQHCwJA6878xvo9tk+vlMfT1qg++UjvOMB8INsOCQIOH2IKErF/8/P21LULkdIrocMw9xA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.47.0':
+    resolution: {integrity: sha512-24D0wsYT/7hDFn3Ow32m3/+QT/1ZwrUhShx4/wRDAmz11GQHOZ1k+/HBuK/MflebdnalmXWITcPEy4BWTi7TCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.47.0':
+    resolution: {integrity: sha512-8tPzPne882mtML/uy3mApvdCyuVOpthJ7xUv3b67gVfz63hOOM/bwO0cysSkPyYYFDFRn6/FnUb7Jhmsesntvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.47.0':
+    resolution: {integrity: sha512-q58pIyGIzeffEBhEgbRxLFHmHfV9m7g1RnkLiahQuEvyjKNiJcvdHOwKH2BdgZxdzc99Cs6hF5xTa86X40WzPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.47.0':
+    resolution: {integrity: sha512-e7DiLZtETZUCwTa4EEHg9G+7g3pY+afCWXvSeMG7m0TQ29UHHxMARPaEQUE4mfKgSqIWnJaUk2iZzRPMRdga5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.47.0':
+    resolution: {integrity: sha512-3AFPfQ0WKMleT/bKd7zsks3xoawtZA6E/wKf0DjwysH7wUiMMJkNKXOzYq1R/00G98JFgSU1AkrlOQrSdNNhlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.47.0':
+    resolution: {integrity: sha512-cLMVVM6TBxp+N7FldQJ2GQnkcLYEPGgiuEaXdvhgvSgODBk9ov3jed+khIXSAWtnFOW0wOnG3RjwqPh0rCuheA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.47.0':
+    resolution: {integrity: sha512-VpFOSzvTnld77/Edje3ZdHgZWnlTb5nVWXyTgjD3/DKF/6t5bRRbwn3z77zOdnGy44xAMvbyAwDNOSeOdVUmRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.47.0':
+    resolution: {integrity: sha512-+q8IWptxXx2HMTM6JluR67284t0h8X/oHJgqpxH1siowxPMqZeIpAcWCUq+tY+Rv2iQK8TUugjZnSBQAVV5CmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@publint/pack@0.1.3':
     resolution: {integrity: sha512-dHDWeutAerz+Z2wFYAce7Y51vd4rbLBfUh0BNnyul4xKoVsPUVJBrOAFsJvtvYBwGFJSqKsxyyHf/7evZ8+Q5Q==}
@@ -2693,6 +2827,16 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxlint@1.47.0:
+    resolution: {integrity: sha512-v7xkK1iv1qdvTxJGclM97QzN8hHs5816AneFAQ0NGji1BMUquhiDAhXpMwp8+ls16uRVJtzVHxP9pAAXblDeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.11.2'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -4177,6 +4321,63 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.112.0': {}
+
+  '@oxlint/binding-android-arm-eabi@1.47.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.47.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.47.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.47.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.47.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.47.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.47.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.47.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.47.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.47.0':
+    optional: true
 
   '@publint/pack@0.1.3': {}
 
@@ -5898,6 +6099,28 @@ snapshots:
       wcwidth: 1.0.1
 
   outdent@0.5.0: {}
+
+  oxlint@1.47.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.47.0
+      '@oxlint/binding-android-arm64': 1.47.0
+      '@oxlint/binding-darwin-arm64': 1.47.0
+      '@oxlint/binding-darwin-x64': 1.47.0
+      '@oxlint/binding-freebsd-x64': 1.47.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.47.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.47.0
+      '@oxlint/binding-linux-arm64-gnu': 1.47.0
+      '@oxlint/binding-linux-arm64-musl': 1.47.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.47.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.47.0
+      '@oxlint/binding-linux-riscv64-musl': 1.47.0
+      '@oxlint/binding-linux-s390x-gnu': 1.47.0
+      '@oxlint/binding-linux-x64-gnu': 1.47.0
+      '@oxlint/binding-linux-x64-musl': 1.47.0
+      '@oxlint/binding-openharmony-arm64': 1.47.0
+      '@oxlint/binding-win32-arm64-msvc': 1.47.0
+      '@oxlint/binding-win32-ia32-msvc': 1.47.0
+      '@oxlint/binding-win32-x64-msvc': 1.47.0
 
   p-filter@2.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,3 +55,4 @@ catalog:
   vitest: ^4.0.18
   vue: ^3.5.27
   vue-eslint-parser: ^10.2.0
+  oxlint: "^1.47.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,4 +55,4 @@ catalog:
   vitest: ^4.0.18
   vue: ^3.5.27
   vue-eslint-parser: ^10.2.0
-  oxlint: "^1.47.0"
+  oxlint: '^1.47.0'


### PR DESCRIPTION
## Motivation:

Recently been using the oxc lint and formatting toolchains on my projects. They are close to supporting most common eslint plugins natively with support for the majority of the eslint js API. I wanted to add oxlint and oxfmt as tooling option in the `@tanstack/cli` builder tool, and since the eslint option used the tanstack/config eslint package I thought that starting here would be a good stepping stone before adding it as an option in the builder CLI

**Info about rule changes**

### Rules not to be implemented

- `no-octal` - Superseded by strict mode: https://github.com/oxc-project/oxc/issues/479

### Rules awaiting implementation

- `no-shadow`
  - Tracking issue: https://github.com/oxc-project/oxc/issues/479
  - Implementation PR: https://github.com/oxc-project/oxc/pull/18979

- `@typescript-eslint/method-signature-style`
  - Tracking issue: https://github.com/oxc-project/oxc/issues/2180

- `@typescript-eslint/naming-convention` - This needs type-aware linting and is discussed if will be implemented or not
  - Comment: https://github.com/oxc-project/oxc/issues/2180#issuecomment-2495480618

- `@typescript-eslint/no-unnecessary-condition` - Not listed in the tracking issue: https://github.com/oxc-project/oxc/issues/2180

### Rules requiring extra TypeScript-native package

TypeScript native (tsgo) is not released yet, so decided to not include these rules as they also [require the user to add an extra oxlint-tsgolint](https://oxc.rs/docs/guide/usage/linter/type-aware.html)

- `@typescript-eslint/no-for-in-array`
- `@typescript-eslint/no-unnecessary-type-assertion`
- `@typescript-eslint/require-await`

## 🎯 Changes

Adds a new oxlint-config package that can be used just like the eslint-config package.

It's almost a one-to-one copy of the `@tanstack/eslint-config` package with some rules omitted due to missing implementations.

**Usage:**
```ts
// oxlint.config.ts
import { defineConfig } from 'oxlint'
import { tanstackConfig } from '@tanstack/oxlint-config'

export default defineConfig({
  extends: [tanstackConfig],
})
```
As far as i know does not support the `.oxlintrc.json` format.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
  - Doesn't effect existing packages, but i have created a changeset for a release.
- [ ] This change is docs/CI/dev-only (no release).
