### PR TITLE
ci: use pull_request_target for PR Version Preview

### DIFF
--- a/.github/changeset-preview/action.yml
+++ b/.github/changeset-preview/action.yml
@@ -1,5 +1,9 @@
 name: Changeset Preview
 description: Generates comment on a PR showing expected version impact
+inputs:
+  workspace:
+    description: Path to the repo checkout to read changesets from. Defaults to GITHUB_WORKSPACE.
+    required: false
 runs:
   using: composite
   steps:
@@ -10,6 +14,8 @@ runs:
     - name: Preview version bumps
       shell: bash
       run: node ${{ github.action_path }}/preview-changeset-versions.mjs --output /tmp/changeset-preview.md
+      env:
+        CHANGESET_WORKSPACE: ${{ inputs.workspace }}
     - name: Post PR comment
       shell: bash
       run: |

--- a/.github/changeset-preview/preview-changeset-versions.mjs
+++ b/.github/changeset-preview/preview-changeset-versions.mjs
@@ -9,7 +9,9 @@ import { resolve } from 'node:path'
 import { parseArgs } from 'node:util'
 import getReleasePlan from '@changesets/get-release-plan'
 
-const GITHUB_WORKSPACE = resolve(process.env.GITHUB_WORKSPACE)
+const GITHUB_WORKSPACE = resolve(
+  process.env.CHANGESET_WORKSPACE || process.env.GITHUB_WORKSPACE,
+)
 
 console.log(`Using workspace: ${GITHUB_WORKSPACE}`)
 

--- a/.github/workflows/pr-version-preview.yml
+++ b/.github/workflows/pr-version-preview.yml
@@ -1,0 +1,32 @@
+name: Version Preview
+
+on:
+  pull_request_target:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  version-preview:
+    name: Version Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          # Check out the PR head so we can read its changeset files.
+          # IMPORTANT: Do NOT run `pnpm install` or any repo scripts on
+          # this ref — pull_request_target grants elevated permissions,
+          # so executing untrusted code would be a security risk.
+          ref: refs/pull/${{ github.event.number }}/merge
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version-file: .nvmrc
+      - name: Changeset Preview
+        uses: ./.github/changeset-preview

--- a/.github/workflows/pr-version-preview.yml
+++ b/.github/workflows/pr-version-preview.yml
@@ -16,17 +16,22 @@ jobs:
     name: Version Preview
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      # First checkout: base branch (trusted) — used for action code
+      - name: Checkout base
         uses: actions/checkout@v6.0.2
         with:
-          # Check out the PR head so we can read its changeset files.
-          # IMPORTANT: Do NOT run `pnpm install` or any repo scripts on
-          # this ref — pull_request_target grants elevated permissions,
-          # so executing untrusted code would be a security risk.
+          path: base
+      # Second checkout: PR merge ref — only used to read changeset files
+      - name: Checkout PR
+        uses: actions/checkout@v6.0.2
+        with:
           ref: refs/pull/${{ github.event.number }}/merge
+          path: pr
       - name: Setup Node
         uses: actions/setup-node@v6.3.0
         with:
-          node-version-file: .nvmrc
+          node-version-file: base/.nvmrc
       - name: Changeset Preview
-        uses: ./.github/changeset-preview
+        uses: ./base/.github/changeset-preview
+        with:
+          workspace: ${{ github.workspace }}/pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,13 +53,3 @@ jobs:
         uses: danielroe/provenance-action@v0.1.1
         with:
           fail-on-downgrade: true
-  version-preview:
-    name: Version Preview
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-      - name: Setup Tools
-        uses: ./.github/setup
-      - name: Changeset Preview
-        uses: ./.github/changeset-preview


### PR DESCRIPTION
The changeset preview action fails with a 403 when trying to comment on PRs opened from forks. This happens because the pull_request event doesn't grant write permissions to the base repo for fork PRs, so the GitHub token can't post comments.

The fix moves the version-preview job out of pr.yml into its own workflow using pull_request_target, which runs in the context of the base repo and has the necessary permissions. To avoid the well-known security pitfall of running untrusted fork code with elevated permissions, the workflow uses two checkouts: the base branch for the action code and .nvmrc, and the PR merge ref solely for reading changeset files.

The changeset-preview action gains an optional workspace input (CHANGESET_WORKSPACE.) so the script knows to read changesets from the PR checkout rather than the default GITHUB_WORKSPACE. This input is optional and falls back to GITHUB_WORKSPACE, so existing callers in router, query, hotkeys, and form are unaffected.

cc @lachlancollins 