### PR TITLE
ci: harden setup action, disable renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,6 @@
     "group:allNonMajor",
     "schedule:weekly",
     ":approveMajorUpdates",
-    ":automergeMinor",
     ":disablePeerDependencies",
     ":maintainLockFilesMonthly",
     ":semanticCommits",

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,22 +1,17 @@
 name: Setup Tools
-description: Action that sets up Node, pnpm, and caching
+description: Action that sets up Node and pnpm
 runs:
   using: composite
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+      with:
+        cache: false
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .nvmrc
         package-manager-cache: false
-    # - name: Setup pnpm cache
-    #   uses: actions/cache@v5.0.4
-    #   with:
-    #     path: ${{ env.STORE_PATH }}
-    #     key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}-v2
-    #     restore-keys: |
-    #       ${{ runner.os }}-pnpm-store-
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,5 +72,3 @@ jobs:
         uses: ./.github/setup
       - name: Changeset Preview
         uses: ./.github/changeset-preview
-        with:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,6 @@ packages:
   - integrations/*
   - packages/*
 
-allowBuilds:
-  nx: true
-  unrs-resolver: true
-
 catalog:
   '@arethetypeswrong/core': ^0.18.2
   '@changesets/cli': ^2.31.0
@@ -58,3 +54,7 @@ catalog:
   vitest: ^4.1.6
   vue: ^3.5.34
   vue-eslint-parser: ^10.4.0
+
+allowBuilds:
+  nx: true
+  unrs-resolver: false


### PR DESCRIPTION
## 🎯 Changes

- Remove `:automergeMinor`
- Explicitly disable cache from `pnpm/action-setup` (this is default behaviour)
- Remove commented `actions/cache`
- Disallow `unrs-resolver` build

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
