### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TanStack/tanstack-core


### PR DESCRIPTION
As part of our ongoing security hardening, we're mandating specific sensitive release files to be approved by the core maintainers team.