### PR TITLE
renovate: add minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     "helpers:pinGitHubActionDigests",
     "group:allNonMajor",
     "schedule:weekly",
+    "security:minimumReleaseAgeNpm",
     ":approveMajorUpdates",
     ":disablePeerDependencies",
     ":maintainLockFilesMonthly",


### PR DESCRIPTION
## 🎯 Changes

See https://docs.renovatebot.com/upgrade-best-practices/

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to add an extra security-related release delay for npm packages, helping reduce the risk of adopting newly published packages too quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->