### PR TITLE
setup: switch to voidzero-dev/setup-vp

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup Vite+
-      uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+      uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # v1.14.0
       with:
         node-version-file: .nvmrc
         run-install: true

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -10,4 +10,5 @@ runs:
         run-install: true
         cache: false
     - name: Setup pnpm
+      shell: bash
       run: vp install -g pnpm

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -3,15 +3,9 @@ description: Action that sets up Node and pnpm
 runs:
   using: composite
   steps:
-    - name: Setup pnpm
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      with:
-        cache: false
-    - name: Setup Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - name: Setup Vite+
+      uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
       with:
         node-version-file: .nvmrc
-        package-manager-cache: false
-    - name: Install dependencies
-      shell: bash
-      run: pnpm install --frozen-lockfile
+        run-install: true
+        cache: false

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -9,3 +9,5 @@ runs:
         node-version-file: .nvmrc
         run-install: true
         cache: false
+    - name: Setup pnpm
+      run: vp install -g pnpm


### PR DESCRIPTION
## 🎯 Changes

In addition to handling the basics like installing Node and pnpm, this action also installs the global [`vp` CLI](https://viteplus.dev/guide/).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/config/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the repository setup workflow into a single “Setup Vite+” step using the Node version from `.nvmrc`.
  * Automatically runs dependency installation during setup, with caching explicitly turned off.
  * Keeps the separate step that installs `pnpm` globally as part of the setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->